### PR TITLE
fix: add pattern validation to SN field to reject non-alphanumeric characters

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1044,6 +1044,7 @@ paths:
         type: string
         minLength: 1
         maxLength: 256
+        pattern: ^[a-zA-Z0-9_-]+$
       description: Device serial number
       example: SFVA78RABZ12345678
     get:
@@ -5776,7 +5777,15 @@ components:
         sn:
           type: string
           nullable: true
-          description: Serial number of the device.
+          minLength: 1
+          maxLength: 256
+          pattern: ^[a-zA-Z0-9_-]+$
+          description: 'Serial number of the device.
+
+            Must contain only alphanumeric characters, hyphens (-), or underscores
+            (_).
+
+            '
         display_name:
           type: string
           nullable: true
@@ -5940,8 +5949,16 @@ components:
             '
         sn:
           type: string
-          description: Serial number of the device. This field is required when creating
+          minLength: 1
+          maxLength: 256
+          pattern: ^[a-zA-Z0-9_-]+$
+          description: 'Serial number of the device. This field is required when creating
             a device.
+
+            Must contain only alphanumeric characters, hyphens (-), or underscores
+            (_).
+
+            '
     DeviceUpdate:
       allOf:
       - $ref: '#/components/schemas/DeviceProperties'
@@ -5962,6 +5979,15 @@ components:
           sn:
             type: string
             nullable: true
+            minLength: 1
+            maxLength: 256
+            pattern: ^[a-zA-Z0-9_-]+$
+            description: 'Serial number of the device.
+
+              Must contain only alphanumeric characters, hyphens (-), or underscores
+              (_).
+
+              '
           display_name:
             type: string
             nullable: true


### PR DESCRIPTION
## Summary
- Added `pattern: ^[a-zA-Z0-9_-]+$` validation to the `sn` (serial number) field across all device schemas (`DeviceProperties`, `DeviceInput`, `DeviceUpdate`) and the `/v1/devices/sn/{sn}` path parameter
- Added `minLength` and `maxLength` constraints where missing

## Root Cause
The `sn` field had no character pattern validation, allowing Chinese characters and other non-ASCII input to be accepted. The `device_id` field correctly enforced `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`, but `sn` was left unconstrained.

## Changes
- `DeviceProperties.sn`: Added `minLength: 1`, `maxLength: 256`, `pattern: ^[a-zA-Z0-9_-]+$`
- `DeviceInput.sn`: Added `minLength: 1`, `maxLength: 256`, `pattern: ^[a-zA-Z0-9_-]+$`
- `DeviceUpdate.sn`: Added `minLength: 1`, `maxLength: 256`, `pattern: ^[a-zA-Z0-9_-]+$`
- `/v1/devices/sn/{sn}` path parameter: Added `pattern: ^[a-zA-Z0-9_-]+$`

## Testing
- Verified the OpenAPI spec is valid YAML after changes
- Pattern allows standard SN formats like `SFVA78RABZ12345678`, `SN-2025_001`
- Pattern rejects Chinese characters, spaces, and other non-ASCII characters

Closes stayforge/Stayforge-API#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for serial number fields across API endpoints, enforcing alphanumeric characters, underscores, and hyphens only (1-256 characters in length).
  * Improved API specification documentation with clarified character constraints and validation rules for serial identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->