### PR TITLE
fix: add pattern validation to price_id field to reject invalid characters

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5786,7 +5786,13 @@ components:
         price_id:
           type: string
           nullable: true
-          description: Stripe price ID for billing purposes.
+          pattern: ^[a-zA-Z0-9_-]+$
+          description: 'Stripe price ID for billing purposes.
+
+            Must contain only alphanumeric characters, hyphens (-), or underscores
+            (_).
+
+            '
         status:
           $ref: '#/components/schemas/DeviceStatus'
         metadata:
@@ -5970,6 +5976,13 @@ components:
           price_id:
             type: string
             nullable: true
+            pattern: ^[a-zA-Z0-9_-]+$
+            description: 'Stripe price ID for billing purposes.
+
+              Must contain only alphanumeric characters, hyphens (-), or underscores
+              (_).
+
+              '
           status:
             $ref: '#/components/schemas/DeviceStatus'
           metadata:


### PR DESCRIPTION
## Summary
- Added `pattern: ^[a-zA-Z0-9_-]+$` validation to the `price_id` field in `DeviceProperties` and `DeviceUpdate` schemas
- Ensures Stripe price IDs conform to expected alphanumeric format

## Root Cause
The `price_id` field had no character pattern validation, allowing Chinese characters and other non-ASCII input to be accepted. Since this field is intended for Stripe pricing IDs (which follow alphanumeric formats), invalid characters should be rejected with a 400 Bad Request.

## Changes
- `DeviceProperties.price_id`: Added `pattern: ^[a-zA-Z0-9_-]+$` and updated description
- `DeviceUpdate.price_id`: Added `pattern: ^[a-zA-Z0-9_-]+$` and updated description

## Testing
- Verified the OpenAPI spec is valid YAML after changes
- Pattern allows standard Stripe price IDs like `price_1MoBy5LkdIwHu7ixZhnattbh`
- Pattern rejects Chinese characters, spaces, and other non-ASCII characters

Closes stayforge/Stayforge-API#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced validation for price ID fields to enforce stricter character requirements, ensuring compatibility and consistency across the API.
  * Updated documentation to clarify allowed characters in price ID fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->