### PR TITLE
fix: reject non-alphanumeric SN codes in POST /v1/devices

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1384,7 +1384,8 @@
           "schema": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 256
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9_-]+$"
           },
           "description": "Device serial number",
           "example": "SFVA78RABZ12345678"
@@ -7308,6 +7309,7 @@
           "sn": {
             "type": "string",
             "nullable": true,
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Serial number of the device."
           },
           "display_name": {
@@ -7447,6 +7449,7 @@
           },
           "sn": {
             "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Serial number of the device. This field is required when creating a device."
           }
         }
@@ -7469,7 +7472,8 @@
               },
               "sn": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "pattern": "^[a-zA-Z0-9_-]+$"
               },
               "display_name": {
                 "type": "string",
@@ -7500,6 +7504,7 @@
         "properties": {
           "sn": {
             "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Device serial number",
             "example": "SFVA78RABZ12345678"
           },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1044,6 +1044,7 @@ paths:
         type: string
         minLength: 1
         maxLength: 256
+        pattern: ^[a-zA-Z0-9_-]+$
       description: Device serial number
       example: SFVA78RABZ12345678
     get:
@@ -5776,6 +5777,7 @@ components:
         sn:
           type: string
           nullable: true
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Serial number of the device.
         display_name:
           type: string
@@ -5940,6 +5942,7 @@ components:
             '
         sn:
           type: string
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Serial number of the device. This field is required when creating
             a device.
     DeviceUpdate:
@@ -5962,6 +5965,7 @@ components:
           sn:
             type: string
             nullable: true
+            pattern: ^[a-zA-Z0-9_-]+$
           display_name:
             type: string
             nullable: true
@@ -5982,6 +5986,7 @@ components:
       properties:
         sn:
           type: string
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Device serial number
           example: SFVA78RABZ12345678
         model_name:


### PR DESCRIPTION
## Summary

- Add `pattern: ^[a-zA-Z0-9_-]+$` regex validation to all `sn` (serial number) fields in the OpenAPI spec
- This prevents invalid characters (e.g., Chinese characters, special symbols) from being accepted as device serial numbers

## Root Cause

The `sn` field in the device schemas (DeviceProperties, DeviceCreate, DeviceUpdate, DeviceInfo) and the `/v1/devices/sn/{sn}` path parameter had no format validation, allowing any string including non-alphanumeric characters to be submitted.

## Changes

- `openapi.yaml`: Added `pattern: ^[a-zA-Z0-9_-]+$` to `sn` fields in DeviceProperties, DeviceCreate, DeviceUpdate, DeviceInfo schemas and the path parameter
- `openapi.json`: Same pattern added to the corresponding JSON definitions

## Testing

- Verified the regex pattern `^[a-zA-Z0-9_-]+$` correctly:
  - Accepts: `SFVA78RABZ12345678`, `device-123`, `SN_001`
  - Rejects: strings containing Chinese characters, spaces, or other special characters

Closes stayforge/Stayforge-API#3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Tightened validation for serials and identifier fields (tenant, org, API key, invite, card IDs): allowed characters limited to ASCII letters, numbers, underscores, and hyphens (^[A-Za-z0-9_-]+$). Requests with nonconforming IDs will fail validation.
* **Documentation**
  * Updated field descriptions and error text to clarify the allowed character set and constraints for these identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->