### PR TITLE
fix: validate price_id format to reject invalid characters

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7320,6 +7320,7 @@
           "price_id": {
             "type": "string",
             "nullable": true,
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Stripe price ID for billing purposes."
           },
           "status": {
@@ -7479,7 +7480,8 @@
               },
               "price_id": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "pattern": "^[a-zA-Z0-9_-]+$"
               },
               "status": {
                 "$ref": "#/components/schemas/DeviceStatus"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5786,6 +5786,7 @@ components:
         price_id:
           type: string
           nullable: true
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Stripe price ID for billing purposes.
         status:
           $ref: '#/components/schemas/DeviceStatus'
@@ -5970,6 +5971,7 @@ components:
           price_id:
             type: string
             nullable: true
+            pattern: ^[a-zA-Z0-9_-]+$
           status:
             $ref: '#/components/schemas/DeviceStatus'
           metadata:


### PR DESCRIPTION
## Summary

- Add `pattern: ^[a-zA-Z0-9_-]+$` regex validation to all `price_id` fields in the OpenAPI spec
- This prevents invalid characters (e.g., Chinese characters, special symbols) from being accepted as pricing IDs

## Root Cause

The `price_id` field in the device schemas (DeviceProperties, DeviceUpdate) had no format validation, allowing any string including non-alphanumeric characters to be submitted. Stripe pricing IDs only contain alphanumeric characters, hyphens, and underscores.

## Changes

- `openapi.yaml`: Added `pattern: ^[a-zA-Z0-9_-]+$` to `price_id` fields in DeviceProperties and DeviceUpdate schemas
- `openapi.json`: Same pattern added to the corresponding JSON definitions

## Testing

- Verified the regex pattern `^[a-zA-Z0-9_-]+$` correctly:
  - Accepts: `price_1234`, `price-abc`, `priceABC123`
  - Rejects: strings containing Chinese characters, spaces, or other special characters

Closes stayforge/Stayforge-API#4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * API schema: device-related price_id fields now must contain only letters, numbers, underscores, or hyphens (pattern ^[a-zA-Z0-9_-]+$).
  * Device update endpoints: price_id remains nullable but, if provided, must match the same allowed-format pattern.
  * Result: tighter validation for price identifiers to prevent invalid values when creating or updating devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->