### PR TITLE
fix: add input validation for sn and price_id fields

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7308,6 +7308,7 @@
           "sn": {
             "type": "string",
             "nullable": true,
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Serial number of the device."
           },
           "display_name": {
@@ -7320,6 +7321,7 @@
           "price_id": {
             "type": "string",
             "nullable": true,
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Stripe price ID for billing purposes."
           },
           "status": {
@@ -7447,6 +7449,7 @@
           },
           "sn": {
             "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Serial number of the device. This field is required when creating a device."
           }
         }
@@ -7469,7 +7472,8 @@
               },
               "sn": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "pattern": "^[a-zA-Z0-9_-]+$"
               },
               "display_name": {
                 "type": "string",
@@ -7479,7 +7483,8 @@
               },
               "price_id": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "pattern": "^[a-zA-Z0-9_-]+$"
               },
               "status": {
                 "$ref": "#/components/schemas/DeviceStatus"
@@ -7500,6 +7505,7 @@
         "properties": {
           "sn": {
             "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "description": "Device serial number",
             "example": "SFVA78RABZ12345678"
           },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5776,6 +5776,7 @@ components:
         sn:
           type: string
           nullable: true
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Serial number of the device.
         display_name:
           type: string
@@ -5786,6 +5787,7 @@ components:
         price_id:
           type: string
           nullable: true
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Stripe price ID for billing purposes.
         status:
           $ref: '#/components/schemas/DeviceStatus'
@@ -5940,6 +5942,7 @@ components:
             '
         sn:
           type: string
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Serial number of the device. This field is required when creating
             a device.
     DeviceUpdate:
@@ -5962,6 +5965,7 @@ components:
           sn:
             type: string
             nullable: true
+            pattern: ^[a-zA-Z0-9_-]+$
           display_name:
             type: string
             nullable: true
@@ -5970,6 +5974,7 @@ components:
           price_id:
             type: string
             nullable: true
+            pattern: ^[a-zA-Z0-9_-]+$
           status:
             $ref: '#/components/schemas/DeviceStatus'
           metadata:
@@ -5982,6 +5987,7 @@ components:
       properties:
         sn:
           type: string
+          pattern: ^[a-zA-Z0-9_-]+$
           description: Device serial number
           example: SFVA78RABZ12345678
         model_name:


### PR DESCRIPTION
## Summary
- Add regex pattern validation (`^[a-zA-Z0-9_-]+$`) to the `sn` (serial number) field to reject Chinese characters and other non-ASCII input
- Add the same regex pattern validation to the `price_id` field to enforce Stripe-compatible pricing ID format
- Validation applied across all relevant schemas: `DeviceProperties`, `DeviceInput`, `DeviceUpdate`, and `DeviceInfo`

## Root Cause
The `sn` and `price_id` fields in the OpenAPI spec had no `pattern` constraint, allowing any string input including Chinese characters and other non-ASCII text. This is invalid because:
- Serial numbers should only contain alphanumeric characters, hyphens, and underscores
- Stripe price IDs follow a strict alphanumeric format (e.g., `price_1ABC2DEF`)

## Changes
- `openapi.yaml`: Added `pattern: ^[a-zA-Z0-9_-]+$` to all `sn` and `price_id` field definitions
- `openapi.json`: Added `"pattern": "^[a-zA-Z0-9_-]+$"` to all corresponding `sn` and `price_id` field definitions

### Affected schemas:
| Schema | Field | Change |
|--------|-------|--------|
| `DeviceProperties` | `sn` | Added pattern |
| `DeviceProperties` | `price_id` | Added pattern |
| `DeviceInput` | `sn` | Added pattern |
| `DeviceUpdate` | `sn` | Added pattern |
| `DeviceUpdate` | `price_id` | Added pattern |
| `DeviceInfo` | `sn` | Added pattern |

## Test Plan
- [ ] Verify that POST /v1/devices rejects `sn` values containing Chinese characters (e.g., `{"sn": "测试设备"}`)
- [ ] Verify that POST /v1/devices accepts valid `sn` values (e.g., `{"sn": "SFVA78RABZ12345678"}`)
- [ ] Verify that `price_id` rejects Chinese characters (e.g., `{"price_id": "价格"}`)
- [ ] Verify that `price_id` accepts valid Stripe IDs (e.g., `{"price_id": "price_1ABC2DEF"}`)
- [ ] Verify that null values are still accepted for nullable fields
- [ ] Validate the OpenAPI spec with a linter to confirm no syntax errors

Closes stayforge/Stayforge-API#3
Closes stayforge/Stayforge-API#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced API input validation on identifier fields (serial numbers, organization IDs, tenant IDs, etc.) to enforce consistent formatting rules, requiring alphanumeric characters with hyphens and underscores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->