### PR TITLE
fix: validate effective_at against new invalid_at when both updated

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -657,7 +657,7 @@
             }
           },
           "422": {
-            "description": "Unprocessable Entity - Request is well-formed but contains semantic errors.\nError codes: `unprocessable_entity`\n",
+            "description": "Unprocessable Entity - Request is well-formed but contains semantic errors.\nFor time validation: `effective_at` must be earlier than `invalid_at`. When both fields are provided in the same request, they are validated against each other (the new values), not against the currently stored values.\nError codes: `unprocessable_entity`\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7090,13 +7090,13 @@
             "type": "string",
             "format": "date-time",
             "nullable": true,
-            "description": "Effective time (when the card becomes active).\nMust be the current time or a future time.\n**⚠️Default: `UTC`**, recommended to use the format `2025-02-16T12:00:00+01:00` to ensure the correct time zone.\nAbout ISO 8601: https://en.wikipedia.org/wiki/ISO_8601\n"
+            "description": "Effective time (when the card becomes active).\nMust be the current time or a future time, and must be earlier than `invalid_at`.\nWhen updating both `effective_at` and `invalid_at` in a single PATCH request, `effective_at` is validated against the new `invalid_at` value provided in the request body (not the currently stored `invalid_at`).\n**⚠️Default: `UTC`**, recommended to use the format `2025-02-16T12:00:00+01:00` to ensure the correct time zone.\nAbout ISO 8601: https://en.wikipedia.org/wiki/ISO_8601\n"
           },
           "invalid_at": {
             "type": "string",
             "format": "date-time",
             "nullable": true,
-            "description": "Invalidation time (when the card becomes invalid/expires).\nMust be the current time or a future time.\n**⚠️Default: `UTC`**, recommended to use the format `2025-02-16T12:00:00+01:00` to ensure the correct time zone.\nAbout ISO 8601: https://en.wikipedia.org/wiki/ISO_8601\n"
+            "description": "Invalidation time (when the card becomes invalid/expires).\nMust be the current time or a future time, and must be later than `effective_at`.\nWhen updating both `effective_at` and `invalid_at` in a single PATCH request, `invalid_at` is validated against the new `effective_at` value provided in the request body (not the currently stored `effective_at`).\n**⚠️Default: `UTC`**, recommended to use the format `2025-02-16T12:00:00+01:00` to ensure the correct time zone.\nAbout ISO 8601: https://en.wikipedia.org/wiki/ISO_8601\n"
           },
           "barcode_type": {
             "type": "string",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -502,6 +502,10 @@ paths:
           description: 'Unprocessable Entity - Request is well-formed but contains
             semantic errors.
 
+            For time validation: `effective_at` must be earlier than `invalid_at`.
+            When both fields are provided in the same request, they are validated
+            against each other (the new values), not against the currently stored values.
+
             Error codes: `unprocessable_entity`
 
             '
@@ -5536,7 +5540,11 @@ components:
           nullable: true
           description: 'Effective time (when the card becomes active).
 
-            Must be the current time or a future time.
+            Must be the current time or a future time, and must be earlier than `invalid_at`.
+
+            When updating both `effective_at` and `invalid_at` in a single PATCH request,
+            `effective_at` is validated against the new `invalid_at` value provided in
+            the request body (not the currently stored `invalid_at`).
 
             **⚠️Default: `UTC`**, recommended to use the format `2025-02-16T12:00:00+01:00`
             to ensure the correct time zone.
@@ -5550,7 +5558,11 @@ components:
           nullable: true
           description: 'Invalidation time (when the card becomes invalid/expires).
 
-            Must be the current time or a future time.
+            Must be the current time or a future time, and must be later than `effective_at`.
+
+            When updating both `effective_at` and `invalid_at` in a single PATCH request,
+            `invalid_at` is validated against the new `effective_at` value provided in
+            the request body (not the currently stored `effective_at`).
 
             **⚠️Default: `UTC`**, recommended to use the format `2025-02-16T12:00:00+01:00`
             to ensure the correct time zone.


### PR DESCRIPTION
## Summary
- Updated `effective_at` and `invalid_at` field descriptions in `CardProperties` schema to clarify that `effective_at` must be earlier than `invalid_at`
- Added documentation that when both fields are updated in a single PATCH request, they are validated against each other (the new values from the request body), not against the currently stored values
- Updated the PATCH `422` error description to explicitly describe this time validation behavior
- Applied changes to both `openapi.yaml` and `openapi.json`

Closes #6

## Test plan
- [ ] Verify `openapi.yaml` is valid YAML
- [ ] Verify `openapi.json` is valid JSON
- [ ] Confirm `effective_at` description now mentions validation against `invalid_at`
- [ ] Confirm `invalid_at` description now mentions validation against `effective_at`
- [ ] Confirm PATCH 422 error description clarifies the validation uses new values when both are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved card API documentation with enhanced descriptions of time field validation requirements and constraints.
  * Updated error messages for card creation and modification endpoints to better explain validation failures.
  * Added clarity on validation behavior when updating multiple time-related fields in a single request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->