### PR TITLE
fix: validate SN field rejects non-alphanumeric characters

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1384,7 +1384,8 @@
           "schema": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 256
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9]+$"
           },
           "description": "Device serial number",
           "example": "SFVA78RABZ12345678"
@@ -7308,7 +7309,10 @@
           "sn": {
             "type": "string",
             "nullable": true,
-            "description": "Serial number of the device."
+            "description": "Serial number of the device.",
+            "pattern": "^[a-zA-Z0-9]+$",
+            "minLength": 1,
+            "maxLength": 256
           },
           "display_name": {
             "type": "string",
@@ -7447,7 +7451,10 @@
           },
           "sn": {
             "type": "string",
-            "description": "Serial number of the device. This field is required when creating a device."
+            "description": "Serial number of the device. This field is required when creating a device.",
+            "pattern": "^[a-zA-Z0-9]+$",
+            "minLength": 1,
+            "maxLength": 256
           }
         }
       },
@@ -7469,7 +7476,10 @@
               },
               "sn": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "pattern": "^[a-zA-Z0-9]+$",
+                "minLength": 1,
+                "maxLength": 256
               },
               "display_name": {
                 "type": "string",
@@ -7501,7 +7511,10 @@
           "sn": {
             "type": "string",
             "description": "Device serial number",
-            "example": "SFVA78RABZ12345678"
+            "example": "SFVA78RABZ12345678",
+            "pattern": "^[a-zA-Z0-9]+$",
+            "minLength": 1,
+            "maxLength": 256
           },
           "model_name": {
             "type": "string",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1044,6 +1044,7 @@ paths:
         type: string
         minLength: 1
         maxLength: 256
+        pattern: ^[a-zA-Z0-9]+$
       description: Device serial number
       example: SFVA78RABZ12345678
     get:
@@ -5777,6 +5778,9 @@ components:
           type: string
           nullable: true
           description: Serial number of the device.
+          minLength: 1
+          maxLength: 256
+          pattern: ^[a-zA-Z0-9]+$
         display_name:
           type: string
           nullable: true
@@ -5942,6 +5946,9 @@ components:
           type: string
           description: Serial number of the device. This field is required when creating
             a device.
+          minLength: 1
+          maxLength: 256
+          pattern: ^[a-zA-Z0-9]+$
     DeviceUpdate:
       allOf:
       - $ref: '#/components/schemas/DeviceProperties'
@@ -5962,6 +5969,9 @@ components:
           sn:
             type: string
             nullable: true
+            minLength: 1
+            maxLength: 256
+            pattern: ^[a-zA-Z0-9]+$
           display_name:
             type: string
             nullable: true
@@ -5984,6 +5994,9 @@ components:
           type: string
           description: Device serial number
           example: SFVA78RABZ12345678
+          minLength: 1
+          maxLength: 256
+          pattern: ^[a-zA-Z0-9]+$
         model_name:
           type: string
           description: Device model name


### PR DESCRIPTION
## Summary
- Adds regex pattern validation (`^[a-zA-Z0-9]+$`) to the `sn` field across all device schemas
- Adds `minLength`/`maxLength` constraints where missing
- Adds pattern to the `/v1/devices/sn/{sn}` path parameter

## Root Cause
The SN field had no character set validation, allowing any Unicode characters (including Chinese characters) to be accepted as serial numbers.

## Changes
- `DeviceProperties.sn`: Added `pattern`, `minLength`, `maxLength`
- `DeviceInput.sn`: Added `pattern`, `minLength`, `maxLength`
- `DeviceUpdate.sn`: Added `pattern`, `minLength`, `maxLength`
- `DeviceInfo.sn`: Added `pattern`, `minLength`, `maxLength`
- Path parameter `sn` in `/v1/devices/sn/{sn}`: Added `pattern`
- Updated both `openapi.yaml` and `openapi.json`

## Testing
- SN codes with Chinese characters (e.g., `SN202501是2002`) will now be rejected with a 422 error
- Valid alphanumeric SN codes (e.g., `SFVA78RABZ12345678`) continue to work

Closes stayforge/Stayforge-API#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Stricter API validation for device serial numbers: now limited to alphanumeric characters with length constraints (1-256 characters).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->