### PR TITLE
fix: validate price_id field rejects non-Stripe formats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7320,7 +7320,8 @@
           "price_id": {
             "type": "string",
             "nullable": true,
-            "description": "Stripe price ID for billing purposes."
+            "description": "Stripe price ID for billing purposes.",
+            "pattern": "^price_[a-zA-Z0-9_]+$"
           },
           "status": {
             "$ref": "#/components/schemas/DeviceStatus"
@@ -7479,7 +7480,8 @@
               },
               "price_id": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "pattern": "^price_[a-zA-Z0-9_]+$"
               },
               "status": {
                 "$ref": "#/components/schemas/DeviceStatus"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5787,6 +5787,7 @@ components:
           type: string
           nullable: true
           description: Stripe price ID for billing purposes.
+          pattern: ^price_[a-zA-Z0-9_]+$
         status:
           $ref: '#/components/schemas/DeviceStatus'
         metadata:
@@ -5970,6 +5971,7 @@ components:
           price_id:
             type: string
             nullable: true
+            pattern: ^price_[a-zA-Z0-9_]+$
           status:
             $ref: '#/components/schemas/DeviceStatus'
           metadata:


### PR DESCRIPTION
## Summary
- Adds regex pattern validation (`^price_[a-zA-Z0-9_]+$`) to the `price_id` field in device schemas
- Ensures price_id values conform to the Stripe pricing ID format

## Root Cause
The `price_id` field had no format validation, allowing any Unicode characters (including Chinese characters like `pricdee二hly`) to be accepted despite being intended for Stripe pricing IDs.

## Changes
- `DeviceProperties.price_id`: Added `pattern: ^price_[a-zA-Z0-9_]+$`
- `DeviceUpdate.price_id`: Added `pattern: ^price_[a-zA-Z0-9_]+$`
- Updated both `openapi.yaml` and `openapi.json`

## Testing
- Invalid price IDs with Chinese characters (e.g., `pricdee二hly`) will now be rejected with a 422 error
- Valid Stripe price IDs (e.g., `price_1abc2def3`) continue to work

Closes stayforge/Stayforge-API#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API schemas to enforce validation on price identification fields across device and card resources. Price IDs must now adhere to the specified format pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->